### PR TITLE
무한 루프 수정 && pipe 수정

### DIFF
--- a/run_test/srcs/start_shell.c
+++ b/run_test/srcs/start_shell.c
@@ -90,6 +90,7 @@ int		start_shell(char **en, char *av)
 		if (synerror_checker(line, ';'))
 			return (EXIT_FAILURE);
 		coms = make_big_tok(line);
+		free(line);
 		status = run_cmd(coms->child, en, av);
 	}
 	return (0);


### PR DESCRIPTION
1) 무한 터미널을 만들어냈던 이유
수정 전 -> run.c - excute_ps 함수에 보면 조건 없이 무조건 pipe_close를 해주었기 때문!
수정 후 -> pipe가 열렸을 때만 pipe_close를 해주는 조건문을 추가함

2) pipe 수정
오류의 이유 : sqlit_qoute에서 구분자가 연속으로 나올때 빈 문자열을 할당해서 뱉어주는데, 그것이 그대로 sible화가 되어 명령어로 들어갔기 때문에! 그래서 빈 문자열인 노드가 명령어 처럼 실행이 되고, 그로인해 없는 명령어 실행이라는 오류가 떴던 것!

test 해볼때  (echo 123|grep 1) <- 요 문자 그대로 해본다면 결과가 알맞게 나오는 것을 확인해볼 수 있음
!!!!내일 sqlit_qoute를 꼭 제대로 수정해 봅시다 😭!!!!
### **꼭 수정된 코드로 make test를 해볼것! 그렇지 않으면 또 무한 터미널이 되어 컴퓨터를 재시동해야합니다!!!!!!!!**